### PR TITLE
ndarray: Add naive Dimension implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
-*.egg-info/
+/.coverage
+/*.egg-info/
 /venv/

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.egg-info/
+/venv/

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,7 @@ matrix:
       sudo: true
 
 script:
-  - pip3 install .
-  - pip3 install coverage
-  - pip3 install codecov
+  - pip3 install .[test]
   - python3 setup.py test
   - coverage run setup.py test
   - codecov

--- a/nptyping/__init__.py
+++ b/nptyping/__init__.py
@@ -4,7 +4,7 @@ from nptyping.functions._py_type import py_type
 from nptyping.types._bool import Bool
 from nptyping.types._complex import Complex128
 from nptyping.types._datetime64 import Datetime64
-from nptyping.types._ndarray import NDArray
+from nptyping.types._ndarray import Dimension, NDArray
 from nptyping.types._nptype import NPType
 from nptyping.types._number import (
     DEFAULT_INT_BITS,

--- a/nptyping/types/_ndarray.py
+++ b/nptyping/types/_ndarray.py
@@ -2,7 +2,7 @@ from typing import Type
 
 import numpy as np
 
-from nptyping.types._ndarray_meta import _NDArray
+from nptyping.types._ndarray_meta import _NDArray, Dimension
 
 
 class NDArray(_NDArray, np.ndarray):

--- a/nptyping/types/_ndarray_meta.py
+++ b/nptyping/types/_ndarray_meta.py
@@ -6,9 +6,11 @@ from typish import SubscriptableType, Literal, ClsFunction, EllipsisType
 
 from nptyping.types._nptype import NPType
 
+_RawSize = Union[int, Literal[Any]]
+
 
 class Dimension:
-    def __init__(self, name, value=Any):
+    def __init__(self, name: str, value: _RawSize=Any):
         assert len(name) > 0
         self._name = name
         self._value = value
@@ -16,15 +18,13 @@ class Dimension:
     def __repr__(self):
         return self._name
 
-    def __eq__(self, other):
+    def __eq__(self, other: _RawSize):
         # Value-only comparison.
-        if isinstance(other, Dimension):
-            return self._value == other._value
-        else:
-            return self._value == other
+        assert not isinstance(other, Dimension)
+        return self._value == other
 
 
-_Size = Union[int, Literal[Any], Dimension]  # TODO add type vars as well
+_Size = Union[_RawSize, Dimension]  # TODO add type vars as well
 _Type = Union[type, Literal[Any], np.dtype]
 _NSizes = Tuple[_Size, EllipsisType]
 _SizeAndType = Tuple[_Size, _Type]

--- a/nptyping/types/_ndarray_meta.py
+++ b/nptyping/types/_ndarray_meta.py
@@ -6,7 +6,25 @@ from typish import SubscriptableType, Literal, ClsFunction, EllipsisType
 
 from nptyping.types._nptype import NPType
 
-_Size = Union[int, Literal[Any]]  # TODO add type vars as well
+
+class Dimension:
+    def __init__(self, name, value=Any):
+        assert len(name) > 0
+        self._name = name
+        self._value = value
+
+    def __repr__(self):
+        return self._name
+
+    def __eq__(self, other):
+        # Value-only comparison.
+        if isinstance(other, Dimension):
+            return self._value == other._value
+        else:
+            return self._value == other
+
+
+_Size = Union[int, Literal[Any], Dimension]  # TODO add type vars as well
 _Type = Union[type, Literal[Any], np.dtype]
 _NSizes = Tuple[_Size, EllipsisType]
 _SizeAndType = Tuple[_Size, _Type]
@@ -23,7 +41,7 @@ _NSizesAndTypeAny = Tuple[_NSizes, Literal[Any]]
 
 
 def _is_eq_to(this: Any, that: Any) -> bool:
-    return that is Any or this == that
+    return that == Any or this == that
 
 
 class _NDArrayMeta(SubscriptableType):
@@ -34,7 +52,7 @@ class _NDArrayMeta(SubscriptableType):
     def shape(cls) -> Tuple[int, ...]:
         """
         Return the shape as a tuple of ints.
-        :return: the shape as a tuple of ints.
+        :return: the shape as a tuple of ints. -1 implies a dynamic size.
         """
         return cls._shape
 

--- a/nptyping/types/_ndarray_meta.py
+++ b/nptyping/types/_ndarray_meta.py
@@ -18,10 +18,12 @@ class Dimension:
     def __repr__(self):
         return self._name
 
-    def __eq__(self, other: _RawSize):
+    def __eq__(self, other: Union[_RawSize, "Dimension"]):
         # Value-only comparison.
-        assert not isinstance(other, Dimension)
-        return self._value == other
+        if isinstance(other, Dimension):
+            return self._value == other._value
+        else:
+            return self._value == other
 
 
 _Size = Union[_RawSize, Dimension]  # TODO add type vars as well

--- a/tests/test_types/test_ndarray.py
+++ b/tests/test_types/test_ndarray.py
@@ -3,7 +3,7 @@ from unittest import TestCase
 
 import numpy as np
 
-from nptyping import NDArray, DEFAULT_INT_BITS, Int, Bool, Datetime64
+from nptyping import NDArray, DEFAULT_INT_BITS, Int, Bool, Datetime64, Dimension
 from nptyping.types._timedelta64 import Timedelta64
 
 
@@ -202,3 +202,18 @@ class TestNDArray(TestCase):
         self.assertNotIsInstance(np.array([[True, False], [True, 42]]), NDArray[(Any, ...), Bool])
         self.assertIsInstance(np.array([np.datetime64()]), NDArray[(Any, ...), Datetime64])
         self.assertIsInstance(np.array([np.timedelta64()]), NDArray[(Any, ...), Timedelta64])
+
+    def test_instance_check_dimension(self):
+        arr2x2x2_float = np.array([[[1.0, 2.0], [3.0, 4.0]],
+                                  [[5.0, 6.0], [7.0, 8.0]]])
+        arr2_float = np.array([1.0, 2.0])
+        arr2x2x2 = np.array([[[1, 2], [3, 4]], [[5, 6], [7, 8]]])
+
+        D = Dimension("D")
+        self.assertEqual(str(D), "D")
+
+        hint = NDArray[(D, D, 2), float]
+        self.assertEqual(str(hint), "NDArray[(D, D, 2), Float[64]]")
+        self.assertIsInstance(arr2x2x2_float, hint)
+        self.assertNotIsInstance(arr2_float, hint)
+        self.assertNotIsInstance(arr2x2x2, hint)

--- a/tests/test_types/test_ndarray.py
+++ b/tests/test_types/test_ndarray.py
@@ -209,11 +209,21 @@ class TestNDArray(TestCase):
         arr2_float = np.array([1.0, 2.0])
         arr2x2x2 = np.array([[[1, 2], [3, 4]], [[5, 6], [7, 8]]])
 
+        # Value is implicity Any.
         D = Dimension("D")
         self.assertEqual(str(D), "D")
-
         hint = NDArray[(D, D, 2), float]
         self.assertEqual(str(hint), "NDArray[(D, D, 2), Float[64]]")
+        self.assertEqual(hint.shape, (Any, Any, 2))
+        self.assertEqual(hint.shape, (D, D, 2))
         self.assertIsInstance(arr2x2x2_float, hint)
         self.assertNotIsInstance(arr2_float, hint)
         self.assertNotIsInstance(arr2x2x2, hint)
+
+        # Concrete value.
+        D2 = Dimension("D2", value=2)
+        self.assertEqual(str(D2), "D2")
+        self.assertEqual(D2, 2)
+        hint2 = NDArray[(D, D, D2), float]
+        self.assertEqual(str(hint2), "NDArray[(D, D, D2), Float[64]]")
+        self.assertEqual(hint2, hint)


### PR DESCRIPTION
Towards #12

This only implements the named column / dimension stuff.

I chose `Dimension` 'cause Tensorflow mentioned it in their RFC, and it seemed a bit more generic to n-dimension arrays than "column"?
https://github.com/tensorflow/community/blob/d71d1ccb3afeaf79bb294eb038dacda908e6d704/rfcs/20200211-tf-types.md
![image](https://user-images.githubusercontent.com/26719449/89828912-be3b8280-db27-11ea-963e-e9d412a3c9d5.png)
