### PR TITLE
fix incorrect typish version requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open('README.md', mode='r', encoding='utf-8') as f:
 
 requirements = [
     'numpy',
-    'typish>=1.5.2',
+    'typish>=1.7.0',
 ],
 
 test_requirements = [


### PR DESCRIPTION
On typish 1.5.3 I got the following error:
```
  File "/gscratch/home/user/miniconda3/envs/majoanalysis/lib/python3.8/site-packages/nptyping/__init__.py", line 2, in <module>
    from nptyping.functions._get_type import get_type
  File "/gscratch/home/user/miniconda3/envs/majoanalysis/lib/python3.8/site-packages/nptyping/functions/_get_type.py", line 8, in <module>
    from nptyping.types._bool import Bool
  File "/gscratch/home/user/miniconda3/envs/majoanalysis/lib/python3.8/site-packages/nptyping/types/_bool.py", line 4, in <module>
    from typish import get_mro
ImportError: cannot import name 'get_mro' from 'typish' (/gscratch/home/user/miniconda3/envs/majoanalysis/lib/python3.8/site-packages/typish/__init__.py)
```
Updating to 1.7.0 fixed the problem.
```
(majoanalysis) user@ip-0A490009:~/majoanalysis/notebooks/topogap_report$ pip install typish
Requirement already satisfied: typish in /gscratch/home/user/miniconda3/envs/majoanalysis/lib/python3.8/site-packages (1.5.3)
(majoanalysis) user@ip-0A490009:~/majoanalysis/notebooks/topogap_report$ pip install -U typish
Collecting typish
  Using cached typish-1.7.0-py3-none-any.whl (43 kB)
Installing collected packages: typish
  Attempting uninstall: typish
    Found existing installation: typish 1.5.3
    Uninstalling typish-1.5.3:
      Successfully uninstalled typish-1.5.3
Successfully installed typish-1.7.0
```