### PR TITLE
BUG: fix validation for 0D arrays

### DIFF
--- a/nptyping/functions/_get_type.py
+++ b/nptyping/functions/_get_type.py
@@ -71,7 +71,8 @@ def _get_type_dtype(dtype: numpy.dtype) -> Type['NPType']:
 def _get_type_arrary(arr: numpy.ndarray) -> Type['NPType']:
     # Return the nptyping type of a numpy array.
     type_ = get_type(arr.dtype)
-    return NDArray[arr.shape, type_]
+    shape = arr.shape or (Any, ...)
+    return NDArray[shape, type_]
 
 
 def _get_type_of_number(

--- a/nptyping/types/_ndarray_meta.py
+++ b/nptyping/types/_ndarray_meta.py
@@ -74,7 +74,7 @@ class _NDArrayMeta(HashedSubscriptableType):
         np_type = get_type(instance)
         return (np_type.__name__ == cls.__name__
                 and _NDArrayMeta.__subclasscheck__(
-                    cls, _NDArray[instance.shape, instance.dtype]))
+                    cls, _NDArray[instance.shape or (Any, ...), instance.dtype]))
 
     def __subclasscheck__(cls, subclass: type) -> bool:
         """

--- a/tests/test_types/test_ndarray.py
+++ b/tests/test_types/test_ndarray.py
@@ -235,3 +235,7 @@ class TestNDArray(TestCase):
         obj_arr = NDArray[(Any,), object]
         ones = np.ones(shape=(5,))
         self.assertIsInstance(ones, obj_arr)
+
+    def test_validate_0DArray(self):
+        arr = np.array(1)
+        self.assertIsInstance(arr, NDArray)


### PR DESCRIPTION
This is a minimal patch to fix #53
I suspect there should be a better way to accomplish this, but this is the best I can do with limited time on my hands.