### PR TITLE
default message for assert_isinstance

### DIFF
--- a/nptyping/assert_isinstance.py
+++ b/nptyping/assert_isinstance.py
@@ -51,5 +51,5 @@ def assert_isinstance(
     if message:
         assert isinstance(instance, cls), message
     else:
-        assert isinstance(instance, cls)
+        assert isinstance(instance, cls), f"instance={instance!r}, cls={cls!r}"
     return True

--- a/nptyping/assert_isinstance.py
+++ b/nptyping/assert_isinstance.py
@@ -48,8 +48,6 @@ def assert_isinstance(
     :param message: any message that is displayed when the assert check fails.
     :return: the type of cls.
     """
-    if message:
-        assert isinstance(instance, cls), message
-    else:
-        assert isinstance(instance, cls), f"instance={instance!r}, cls={cls!r}"
+    message = message or f"instance={instance!r}, cls={cls!r}"
+    assert isinstance(instance, cls), message
     return True

--- a/tests/test_assert_isinstance.py
+++ b/tests/test_assert_isinstance.py
@@ -8,8 +8,9 @@ class AssertInstanceTest(TestCase):
         assert_isinstance(1, int)
 
     def test_assert_isinstance_false(self):
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(AssertionError) as err:
             assert_isinstance(1, str)
+        self.assertIn("instance=1, cls=<class 'str'>", str(err.exception))
 
     def test_assert_isinstance_false_with_message(self):
         with self.assertRaises(AssertionError) as err:


### PR DESCRIPTION
This PR implements a default message for `assert_isinstance`.

Consider the following example:
```python
# tmp.py
from typing import Any

import numpy as np
from nptyping import NDArray, assert_isinstance

my_arr = np.array([1, 2, 3], dtype=np.float32)
assert_isinstance(my_arr, NDArray[Any, np.int64])
```
### Before the PR:
```text
$ python tmp.py
Traceback (most recent call last):
...
AssertionError
```
The above offers little info as to what caused the failure.
### After the PR:
```text
$ python tmp.py
Traceback (most recent call last):
...
AssertionError: instance=array([1., 2., 3.], dtype=float32), cls=NDArray[Any, Int]
```
This should be enough to diagnose why the assertion failed.