### PR TITLE
Fix typo in test_mypy.py

### DIFF
--- a/tests/test_mypy.py
+++ b/tests/test_mypy.py
@@ -72,7 +72,7 @@ class MyPyTest(TestCase):
             from nptyping import NDArray, Shape
             
             
-            def func(_: NDArray[Any, Shape["2, 2"]]) -> None:
+            def func(_: NDArray[Shape["2, 2"], Any]) -> None:
                 ...
             
             

--- a/tests/test_mypy.py
+++ b/tests/test_mypy.py
@@ -38,7 +38,7 @@ class MyPyTest(TestCase):
             from nptyping import NDArray, Shape
             
             
-            NDArray[Any, Shape["3, 3"]]
+            NDArray[Shape["3, 3"], Any]
         """
         )
 
@@ -52,7 +52,7 @@ class MyPyTest(TestCase):
             from nptyping import NDArray, Shape
             
             
-            def func(_: NDArray[Any, Shape["2, 2"]]) -> None:
+            def func(_: NDArray[Shape["2, 2"], Any]) -> None:
                 ...
             
 


### PR DESCRIPTION
Fixing a typo: the shape should come *before* the dtype, not after.