### PR TITLE
Link at top of README regarding how this library compares to `numpy.typing`

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@
 🧊 *Type hints for `NumPy`* <br/>
 🐼 *Type hints for `pandas.DataFrame`* <br/>
 💡 *Extensive dynamic type checks for dtypes shapes and structures* <br/>
-🚀 *[Jump to the Quickstart](https://github.com/ramonhagenaars/nptyping/blob/master/USERDOCS.md#Quickstart)*
+🚀 *[Jump to the Quickstart](https://github.com/ramonhagenaars/nptyping/blob/master/USERDOCS.md#Quickstart)* <br/>
+📄 *Or, [learn how this library compares with `numpy.typing`](https://github.com/ramonhagenaars/nptyping/blob/master/USERDOCS.md#Similar-projects)*
 
 Example of a hinted `numpy.ndarray`:
 


### PR DESCRIPTION
IMO, the information about how nptyping relates to `numpy.typing` should not be buried in the user documentation.  It should be stated clearly at the top of the README.  Without this spelled out, it would be reasonable for a person to think this repository is just an older version of what is now in `numpy.typing`.  This PR hopes to clarify.

Preview [here](https://github.com/garrison/nptyping/blob/cf-numpy-typing/README.md)